### PR TITLE
refactor: enable dagger logs only with debug flag

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -45,7 +45,13 @@ func NewCommand() *cobra.Command {
 }
 
 func run(ctx context.Context) error {
-	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	var opts []dagger.ClientOpt
+
+	if os.Getenv("RUNNER_DEBUG") == "1" {
+		opts = append(opts, dagger.WithLogOutput(os.Stdout))
+	}
+
+	client, err := dagger.Connect(ctx, opts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/with/job/job.go
+++ b/cmd/with/job/job.go
@@ -29,11 +29,16 @@ func NewCommand() *cobra.Command {
 				return fmt.Errorf("workflow and job name must be provided")
 			}
 
-			client, err := dagger.Connect(cmd.Context(), dagger.WithLogOutput(os.Stdout))
+			var opts []dagger.ClientOpt
+
+			if os.Getenv("RUNNER_DEBUG") == "1" {
+				opts = append(opts, dagger.WithLogOutput(os.Stdout))
+			}
+
+			client, err := dagger.Connect(cmd.Context(), opts...)
 			if err != nil {
 				return err
 			}
-			defer client.Close()
 
 			// TODO: temporary solution to load workflow from current directory. `gh` is missing in runner image
 			workflows, err := repository.LoadWorkflows(cmd.Context(), client, ".")

--- a/cmd/with/step/step.go
+++ b/cmd/with/step/step.go
@@ -32,7 +32,13 @@ func NewCommand() *cobra.Command {
 		Use:   "step",
 		Short: "Add new step to execute",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := dagger.Connect(cmd.Context(), dagger.WithLogOutput(os.Stdout))
+			var opts []dagger.ClientOpt
+
+			if os.Getenv("RUNNER_DEBUG") == "1" {
+				opts = append(opts, dagger.WithLogOutput(os.Stdout))
+			}
+
+			client, err := dagger.Connect(cmd.Context(), opts...)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
To improve the visibility of the action run in the dagger scenario, this PR moves the inner dagger logs to the debug level.